### PR TITLE
Restricting TCRD transform WANTED_TABLES to those in use

### DIFF
--- a/kg_idg/transform_utils/tcrd/tcrd.py
+++ b/kg_idg/transform_utils/tcrd/tcrd.py
@@ -34,11 +34,13 @@ TCRD_CONFIGS = {
 # referenced by others (e.g., data_type)
 # but aren't really useful as transforms
 # so we'll ignore them below
+#WANTED_TABLES = ["data_type","info_type","xref_type",
+#                "protein","target","tdl_info","drug_activity",
+#                "feature","mondo","mondo_parent",
+#                "mondo_xref","pubmed","protein2pubmed"]
 WANTED_TABLES = ["data_type","info_type","xref_type",
-                "protein","target","tdl_info","drug_activity",
-                "feature","mondo","mondo_parent",
-                "mondo_xref","pubmed","protein2pubmed"]
-
+                "protein"]
+                
 TRANSLATION_TABLE = "./kg_idg/transform_utils/translation_table.yaml"
 
 class SplitterArgs:


### PR DESCRIPTION
The TCRD transforms specified a number of tables I haven't set up transforms for yet (and some of minimal overall value).
This is fixed, but a future PR will restore some of them with new transforms.