### PR TITLE
Remove decompressed raw sources

### DIFF
--- a/kg_idg/transform_utils/atc/atc.py
+++ b/kg_idg/transform_utils/atc/atc.py
@@ -76,3 +76,5 @@ class ATCTransform(Transform):
                              output_format="tsv",
                              global_table=TRANSLATION_TABLE,
                              local_table=None)
+
+        os.remove(outpath)

--- a/kg_idg/transform_utils/drug_central/drug_central.py
+++ b/kg_idg/transform_utils/drug_central/drug_central.py
@@ -144,5 +144,7 @@ class DrugCentralTransform(Transform):
                              output_format="tsv",
                              global_table=TRANSLATION_TABLE,
                              local_table=None)
+        
+        os.remove(outpath)
 
 

--- a/kg_idg/transform_utils/hpa/hpa.py
+++ b/kg_idg/transform_utils/hpa/hpa.py
@@ -74,4 +74,4 @@ class ProteinAtlasTransform(Transform):
                              global_table=TRANSLATION_TABLE,
                              local_table=None)
         
-        os.remove(data_file[:-3]) # Compressed source is a zip of a tsv
+        os.remove(data_file[:-4]) # Compressed source is a zip of a tsv

--- a/kg_idg/transform_utils/hpa/hpa.py
+++ b/kg_idg/transform_utils/hpa/hpa.py
@@ -73,3 +73,5 @@ class ProteinAtlasTransform(Transform):
                              output_format="tsv",
                              global_table=TRANSLATION_TABLE,
                              local_table=None)
+        
+        os.remove(data_file[:-3]) # Compressed source is a zip of a tsv

--- a/kg_idg/transform_utils/tcrd/tcrd.py
+++ b/kg_idg/transform_utils/tcrd/tcrd.py
@@ -74,13 +74,17 @@ class TCRDTransform(Transform):
     def parse(self, name: str, data_file: str, source: str) -> None:
         """
         Transform TCRD ID mapping file with Koza.
+        Removes uncompressed raw file when finished.
         """
         print(f"Parsing {data_file}")
         
         outname = name[:-3]
         
+        need_to_remove_raw_source = False
+
         # Decompress
         if name[-2:] == "gz":
+            need_to_remove_raw_source = True
             outpath = os.path.join(self.input_base_dir, outname)
             with gzip.open(data_file, 'rb') as data_file_gz:
                 with open(outpath, 'wb') as data_file_new:
@@ -126,4 +130,7 @@ class TCRDTransform(Transform):
                                 output_format="tsv",
                                 global_table=TRANSLATION_TABLE,
                                 local_table=None)
+
+        if need_to_remove_raw_source:
+            os.remove(outpath)
 


### PR DESCRIPTION
Addressing #51 - decompressed sources are removed after transformation, as the compressed versions are already retained and uploaded during the build's publish stage.