### PR TITLE
Ingest DrugCentral identifiers

### DIFF
--- a/kg_idg/transform_utils/drug_central/drug_central.py
+++ b/kg_idg/transform_utils/drug_central/drug_central.py
@@ -27,7 +27,7 @@ DRUG_CENTRAL_CONFIGS = {
 }
 
 # Reference table must be loaded before property table due to dependency
-WANTED_TABLES = ["atc_ddd","approval","reference","property"]
+WANTED_TABLES = ["atc_ddd","approval","reference","property","identifier"]
 
 TRANSLATION_TABLE = "./kg_idg/transform_utils/translation_table.yaml"
 REFERENCE_MAP_TABLE = "./kg_idg/transform_utils/drug_central/drugcentral-reference_map.tsv"

--- a/kg_idg/transform_utils/drug_central/drugcentral-identifier.py
+++ b/kg_idg/transform_utils/drug_central/drugcentral-identifier.py
@@ -1,0 +1,47 @@
+import uuid
+
+from biolink_model_pydantic.model import Drug #type: ignore
+
+from koza.cli_runner import koza_app #type: ignore
+
+# This parses all DrugCentral cross-references
+# Each row is a single xref to a single ID
+# so they are all combined upon merge
+
+source_name="drugcentral-identifier"
+
+row = koza_app.get_row(source_name)
+
+xref = []
+
+# the following is a map from id_type to
+# preferred prefix
+xref_types = {"CHEBI":"CHEBI",
+                "ChEMBL_ID":"CHEMBL_COMPOUND",
+                "DRUGBANK_ID":"DRUGBANK",
+                "INN_ID":"INN",
+                "IUPHAR_LIGAND_ID":"IUPHAR_LIGAND",
+                "KEGG_DRUG":"KEGG_DRUG",
+                "MESH_DESCRIPTOR_UI":"MESH",
+                "MESH_SUPPLEMENTAL_RECORD_UI":"MESH",
+                "MMSL":"MMSL",
+                "NDDF":"NDDF",
+                "NDFRT":"NDFRT",
+                "NUI":"NUI",
+                "PDB_CHEM_ID":"PDB",
+                "PUBCHEM_CID":"PUBCHEM_COMPOUND",
+                "RXNORM":"RXNORM",
+                "SECONDARY_CAS_RN":"CAS",
+                "SNOMEDCT_US":"SNOMEDCT",
+                "UMLSCUI":"UMLS",
+                "UNII":"UNII",
+                "VANDF":"VANDF",
+                "VUID":"VUID"}
+xref.append(xref_types[str(row["id_type"])] + ":" + str(row["identifier"]))
+
+# Entities
+drug = Drug(id='DrugCentral:' + row["struct_id"],
+            source='DrugCentral',
+            xref=xref)
+
+koza_app.write(drug)

--- a/kg_idg/transform_utils/drug_central/drugcentral-identifier.py
+++ b/kg_idg/transform_utils/drug_central/drugcentral-identifier.py
@@ -1,21 +1,22 @@
 import uuid
 
-from biolink_model_pydantic.model import Drug #type: ignore
+from biolink_model_pydantic.model import Association, Drug, NamedThing, Predicate #type: ignore
 
 from koza.cli_runner import koza_app #type: ignore
 
 # This parses all DrugCentral cross-references
-# Each row is a single xref to a single ID
-# so they are all combined upon merge
+# Each row could be a single xref to a single ID
+# but that isn't supported by BioLink yet
+# so we have a workaround with Association
 
 source_name="drugcentral-identifier"
 
 row = koza_app.get_row(source_name)
 
-xref = []
+# xref = []
 
 # the following is a map from id_type to
-# preferred prefix
+ # preferred prefix
 xref_types = {"CHEBI":"CHEBI",
                 "ChEMBL_ID":"CHEMBL_COMPOUND",
                 "DRUGBANK_ID":"DRUGBANK",
@@ -37,11 +38,28 @@ xref_types = {"CHEBI":"CHEBI",
                 "UNII":"UNII",
                 "VANDF":"VANDF",
                 "VUID":"VUID"}
-xref.append(xref_types[str(row["id_type"])] + ":" + str(row["identifier"]))
+# xref.append(xref_types[str(row["id_type"])] + ":" + str(row["identifier"]))
+
+# drug = Drug(id='DrugCentral:' + row["struct_id"],
+#             source='DrugCentral',
+#             xref=xref)
 
 # Entities
-drug = Drug(id='DrugCentral:' + row["struct_id"],
-            source='DrugCentral',
-            xref=xref)
+# CHEBI IDs already prefixed for some reason
+if str(row["id_type"]) == "CHEBI":
+    xref_curie = NamedThing(id=str(row["identifier"]))
+else:
+    xref_curie = NamedThing(id=xref_types[str(row["id_type"])] + ":" + str(row["identifier"]))
+drug = Drug(id='DrugCentral:' + row["struct_id"])
 
-koza_app.write(drug)
+# Association
+association = Association(
+    id="uuid:" + str(uuid.uuid1()),
+    subject=xref_curie.id,
+    predicate=Predicate.same_as,
+    object=drug.id,
+    relation="owl:sameAs",
+    source="DrugCentral"
+)
+
+koza_app.write(xref_curie, association, drug)

--- a/kg_idg/transform_utils/drug_central/drugcentral-identifier.py
+++ b/kg_idg/transform_utils/drug_central/drugcentral-identifier.py
@@ -13,10 +13,8 @@ source_name="drugcentral-identifier"
 
 row = koza_app.get_row(source_name)
 
-# xref = []
-
 # the following is a map from id_type to
- # preferred prefix
+# preferred prefix
 xref_types = {"CHEBI":"CHEBI",
                 "ChEMBL_ID":"CHEMBL_COMPOUND",
                 "DRUGBANK_ID":"DRUGBANK",
@@ -38,11 +36,6 @@ xref_types = {"CHEBI":"CHEBI",
                 "UNII":"UNII",
                 "VANDF":"VANDF",
                 "VUID":"VUID"}
-# xref.append(xref_types[str(row["id_type"])] + ":" + str(row["identifier"]))
-
-# drug = Drug(id='DrugCentral:' + row["struct_id"],
-#             source='DrugCentral',
-#             xref=xref)
 
 # Entities
 # CHEBI IDs already prefixed for some reason

--- a/kg_idg/transform_utils/drug_central/drugcentral-identifier.yaml
+++ b/kg_idg/transform_utils/drug_central/drugcentral-identifier.yaml
@@ -1,0 +1,35 @@
+name: 'drugcentral-identifier'
+
+format: 'csv'
+
+delimiter: '\t'
+
+files:
+  - './data/transformed/drug_central/drugcentral-identifier.tsv'
+
+metadata: './kg_idg/transform_utils/drug_central/metadata.yaml'
+
+header: 'infer'
+
+columns:
+  - 'id'
+  - 'identifier'
+  - 'id_type'
+  - 'struct_id'
+  - 'parent_match'
+
+node_properties:
+  - 'id'
+  - 'xref'
+  - 'source'
+
+edge_properties:
+  - 'id'
+  - 'subject'
+  - 'predicate'
+  - 'object'
+  - 'category'
+  - 'relation'
+  - 'source'
+
+transform_mode: 'flat'

--- a/kg_idg/transform_utils/drug_central/drugcentral-identifier.yaml
+++ b/kg_idg/transform_utils/drug_central/drugcentral-identifier.yaml
@@ -20,8 +20,8 @@ columns:
 
 node_properties:
   - 'id'
-  - 'xref'
-  - 'source'
+  - 'category'
+  - 'provided_by'
 
 edge_properties:
   - 'id'
@@ -31,5 +31,6 @@ edge_properties:
   - 'category'
   - 'relation'
   - 'source'
+  - 'provided_by'
 
 transform_mode: 'flat'


### PR DESCRIPTION
Fix #44 

These should be xrefs for consistency, but each alternate CURIE is now an Attribute to a Drug with an assumed same_as relation.
In practice many of these are probably not exactly same_as but the extent of these mappings is unclear.