### PR TITLE
Update GO-CAMs to be broader

### DIFF
--- a/download.yaml
+++ b/download.yaml
@@ -57,6 +57,14 @@
   url: https://reactome.org/download/current/UniProt2Reactome_PE_Pathway.txt
   local_name: UniProt2Reactome_PE_Pathway.txt
 -
+  # Reactome - all pathways
+  url: https://reactome.org/download/current/ReactomePathways.txt
+  local_name: ReactomePathways.txt
+-
+  # Reactome - pathway parent/child relationships
+  url: https://reactome.org/download/current/ReactomePathwaysRelation.txt
+  local_name: ReactomePathwaysRelation.txt
+-
   # GOCAMs
   # TODO: Update SPARQL query for COVID-19 retrieval to be more general
   url: https://kg-hub.berkeleybop.io/frozen_incoming_data/GOCAMs_nodes.tsv

--- a/download.yaml
+++ b/download.yaml
@@ -66,7 +66,6 @@
   local_name: ReactomePathwaysRelation.txt
 -
   # GOCAMs
-  # TODO: Update SPARQL query for COVID-19 retrieval to be more general
   url: https://kg-hub.berkeleybop.io/frozen_incoming_data/GOCAMs_nodes.tsv
   local_name: GOCAMs_nodes.tsv
 -

--- a/download.yaml
+++ b/download.yaml
@@ -59,10 +59,10 @@
 -
   # GOCAMs
   # TODO: Update SPARQL query for COVID-19 retrieval to be more general
-  url: https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/GOCAMs/GOCAMs_nodes.tsv
+  url: https://kg-hub.berkeleybop.io/frozen_incoming_data/GOCAMs_nodes.tsv
   local_name: GOCAMs_nodes.tsv
 -
-  url: https://kg-hub.berkeleybop.io/kg-covid-19/current/transformed/GOCAMs/GOCAMs_edges.tsv
+  url: https://kg-hub.berkeleybop.io/frozen_incoming_data/GOCAMs_edges.tsv
   local_name: GOCAMs_edges.tsv
 -
   # Gene Ontology - not the base version

--- a/kg_idg/transform_utils/gocams/gocams-fix-edges.py
+++ b/kg_idg/transform_utils/gocams/gocams-fix-edges.py
@@ -1,0 +1,69 @@
+import uuid
+
+from biolink_model_pydantic.model import ( #type: ignore
+    NamedThing,
+    Pathway,
+    Gene,
+    Protein,
+    Association
+)
+
+from koza.cli_runner import koza_app #type: ignore
+
+source_name="gocams-fix-edges"
+
+def normalize_gocam_id(raw_id,prefix):
+    if prefix == "GO":
+        thing = NamedThing(id=raw_id)
+    elif prefix == "OBO":
+        if raw_id[4:13] == "UniProtKB": # edge case
+            id = "UniProtKB:" + (raw_id.split("_"))[1]
+            thing = Protein(id=id)
+        else:
+            id = "REACT:" + (raw_id.split("#REACTO_"))[1]
+            thing = Pathway(id=id)
+    elif prefix == "MGI":
+        id = "MGI:" + (raw_id.split(":"))[2]
+        thing = Gene(id=id)
+    elif prefix == "FB":
+        id = "FlyBase:" + (raw_id.split(":"))[1]
+        thing = Gene(id=id)
+    elif prefix == "WB":
+        id = "WormBase:" + (raw_id.split(":"))[1]
+        thing = Gene(id=id)
+    elif prefix == "POMBASE":
+        id = "PomBase:" + (raw_id.split(":"))[2]
+        thing = Gene(id=id)                  
+    elif prefix == "UniProtKB": 
+        thing = Protein(id=raw_id)
+    elif prefix in ["DICTYBASE.GENE", "TAIR.LOCUS"]:
+        id = raw_id.replace(".","_")
+        thing = Gene(id=id)
+    elif prefix in ["SGD", "RGD", "XENBASE", "ZFIN"]:
+        thing = Gene(id=raw_id)
+    else:
+        thing = NamedThing(id=raw_id)
+    
+    return thing
+
+row = koza_app.get_row(source_name)
+
+subject_raw_id = (str(row["subject"])).lstrip(":")
+subject_prefix = (subject_raw_id.split(":"))[0]
+subject = normalize_gocam_id(subject_raw_id, subject_prefix)
+
+object_raw_id = (str(row["object"])).lstrip(":")
+object_prefix = (object_raw_id.split(":"))[0]
+object = normalize_gocam_id(object_raw_id, object_prefix)
+
+# Association
+association = Association(
+    id="uuid:" + str(uuid.uuid1()),
+    subject=subject.id,
+    predicate=row["predicate"],
+    object=object.id,
+    relation=row["relation"]
+)
+
+koza_app.write(subject, association, object)
+

--- a/kg_idg/transform_utils/gocams/gocams-fix-edges.py
+++ b/kg_idg/transform_utils/gocams/gocams-fix-edges.py
@@ -13,32 +13,30 @@ from koza.cli_runner import koza_app #type: ignore
 source_name="gocams-fix-edges"
 
 def normalize_gocam_id(raw_id,prefix):
-    if prefix == "GO":
-        thing = NamedThing(id=raw_id)
-    elif prefix == "OBO":
+    if prefix == "OBO":
         if raw_id[4:13] == "UniProtKB": # edge case
-            id = "UniProtKB:" + (raw_id.split("_"))[1]
-            thing = Protein(id=id)
+            curie = "UniProtKB:" + (raw_id.split("_"))[1]
+            thing = Protein(id=curie)
         else:
-            id = "REACT:" + (raw_id.split("#REACTO_"))[1]
-            thing = Pathway(id=id)
+            curie = "REACT:" + (raw_id.split("#REACTO_"))[1]
+            thing = Pathway(id=curie)
     elif prefix == "MGI":
-        id = "MGI:" + (raw_id.split(":"))[2]
-        thing = Gene(id=id)
+        curie = "MGI:" + (raw_id.split(":"))[2]
+        thing = Gene(id=curie)
     elif prefix == "FB":
-        id = "FlyBase:" + (raw_id.split(":"))[1]
-        thing = Gene(id=id)
+        curie = "FlyBase:" + (raw_id.split(":"))[1]
+        thing = Gene(id=curie)
     elif prefix == "WB":
-        id = "WormBase:" + (raw_id.split(":"))[1]
-        thing = Gene(id=id)
+        curie = "WormBase:" + (raw_id.split(":"))[1]
+        thing = Gene(id=curie)
     elif prefix == "POMBASE":
-        id = "PomBase:" + (raw_id.split(":"))[2]
-        thing = Gene(id=id)                  
+        curie = "PomBase:" + (raw_id.split(":"))[2]
+        thing = Gene(id=curie)                  
     elif prefix == "UniProtKB": 
         thing = Protein(id=raw_id)
     elif prefix in ["DICTYBASE.GENE", "TAIR.LOCUS"]:
-        id = raw_id.replace(".","_")
-        thing = Gene(id=id)
+        curie = raw_id.replace(".","_")
+        thing = Gene(id=curie)
     elif prefix in ["SGD", "RGD", "XENBASE", "ZFIN"]:
         thing = Gene(id=raw_id)
     else:

--- a/kg_idg/transform_utils/gocams/gocams-fix-edges.yaml
+++ b/kg_idg/transform_utils/gocams/gocams-fix-edges.yaml
@@ -1,0 +1,36 @@
+name: 'gocams-fix-edges'
+
+format: 'csv'
+
+delimiter: '\t'
+
+files:
+  - './data/raw/GOCAMs_edges.tsv'
+
+metadata: './kg_idg/transform_utils/gocams/metadata.yaml'
+
+header: 'infer'
+
+columns:
+  - 'subject'
+  - 'predicate'
+  - 'object'
+  - 'relation'
+  - 'knowledge_source'
+
+node_properties:
+  - 'id'
+  - 'category'
+  - 'source'
+
+edge_properties:
+  - 'id'
+  - 'subject'
+  - 'predicate'
+  - 'object'
+  - 'category'
+  - 'relation'
+  - 'source'
+  - 'provided_by'
+
+transform_mode: 'flat'

--- a/kg_idg/transform_utils/gocams/gocams-fix-nodes.py
+++ b/kg_idg/transform_utils/gocams/gocams-fix-nodes.py
@@ -1,0 +1,60 @@
+
+from biolink_model_pydantic.model import ( #type: ignore
+    NamedThing,
+    Pathway,
+    Gene,
+    Protein
+)
+
+from koza.cli_runner import koza_app #type: ignore
+
+source_name="gocams-fix-nodes"
+
+row = koza_app.get_row(source_name)
+
+raw_id = (str(row["id"])).lstrip(":")
+prefix = (raw_id.split(":"))[0]
+
+if prefix == "GO":
+    thing = NamedThing(id=row["id"],
+                        source=row["provided_by"])
+elif prefix == "OBO":
+    if raw_id[4:13] == "UniProtKB": # edge case
+        id = "UniProtKB:" + (raw_id.split("_"))[1]
+        thing = Protein(id=id,
+                            source=row["provided_by"])
+    else:
+        id = "REACT:" + (raw_id.split("#REACTO_"))[1]
+        thing = Pathway(id=id,
+                            source=row["provided_by"])
+elif prefix == "MGI":
+    id = "MGI:" + (raw_id.split(":"))[2]
+    thing = Gene(id=id,
+                        source=row["provided_by"])
+elif prefix == "FB":
+    id = "FlyBase:" + (raw_id.split(":"))[1]
+    thing = Gene(id=id,
+                        source=row["provided_by"])
+elif prefix == "WB":
+    id = "WormBase:" + (raw_id.split(":"))[1]
+    thing = Gene(id=id,
+                        source=row["provided_by"])
+elif prefix == "POMBASE":
+    id = "PomBase:" + (raw_id.split(":"))[2]
+    thing = Gene(id=id,
+                        source=row["provided_by"])                  
+elif prefix == "UniProtKB": 
+    thing = Protein(id=row["id"],
+                        source=row["provided_by"])
+elif prefix in ["DICTYBASE.GENE", "TAIR.LOCUS"]:
+    id = str(row["id"]).replace(".","_")
+    thing = Gene(id=id,
+                    source=row["provided_by"])
+elif prefix in ["SGD", "RGD", "XENBASE", "ZFIN"]:
+    thing = Gene(id=row["id"],
+                    source=row["provided_by"])
+else:
+    thing = NamedThing(id=row["id"],
+                        source=row["provided_by"])
+
+koza_app.write(thing)

--- a/kg_idg/transform_utils/gocams/gocams-fix-nodes.py
+++ b/kg_idg/transform_utils/gocams/gocams-fix-nodes.py
@@ -15,10 +15,7 @@ row = koza_app.get_row(source_name)
 raw_id = (str(row["id"])).lstrip(":")
 prefix = (raw_id.split(":"))[0]
 
-if prefix == "GO":
-    thing = NamedThing(id=row["id"],
-                        source=row["provided_by"])
-elif prefix == "OBO":
+if prefix == "OBO":
     if raw_id[4:13] == "UniProtKB": # edge case
         id = "UniProtKB:" + (raw_id.split("_"))[1]
         thing = Protein(id=id,

--- a/kg_idg/transform_utils/gocams/gocams-fix-nodes.yaml
+++ b/kg_idg/transform_utils/gocams/gocams-fix-nodes.yaml
@@ -1,0 +1,34 @@
+name: 'gocams-fix-nodes'
+
+format: 'csv'
+
+delimiter: '\t'
+
+files:
+  - './data/raw/GOCAMs_nodes.tsv'
+
+metadata: './kg_idg/transform_utils/gocams/metadata.yaml'
+
+header: 'infer'
+
+columns:
+  - 'id'
+  - 'category'
+  - 'provided_by'
+
+node_properties:
+  - 'id'
+  - 'category'
+  - 'source'
+
+edge_properties:
+  - 'id'
+  - 'subject'
+  - 'predicate'
+  - 'object'
+  - 'category'
+  - 'relation'
+  - 'source'
+  - 'provided_by'
+
+transform_mode: 'flat'

--- a/kg_idg/transform_utils/gocams/metadata.yaml
+++ b/kg_idg/transform_utils/gocams/metadata.yaml
@@ -1,0 +1,11 @@
+name: 'gocams'
+
+dataset_description:
+  ingest_title: 'gocams'
+  ingest_url: 'https://kg-hub.berkeleybop.io/frozen_incoming_data/'
+  description: 'Gene Ontology Causal Activity Modeling'
+  rights: ''
+
+source_files:
+  - 'gocams-fix-nodes.yaml'
+  - 'gocams-fix-edges.yaml'

--- a/kg_idg/transform_utils/reactome/chebi2reactome.py
+++ b/kg_idg/transform_utils/reactome/chebi2reactome.py
@@ -17,7 +17,6 @@ row = koza_app.get_row(source_name)
 # Entities
 chemical = ChemicalEntity(id='CHEBI:' + row['CHEBI_ID'])
 pathway = Pathway(id='REACT:' + row['REACT_PATH_ID'],
-                    description= row['EVENT_NAME'],
                     source=full_source_name)
 
 # Association

--- a/kg_idg/transform_utils/reactome/reactome.py
+++ b/kg_idg/transform_utils/reactome/reactome.py
@@ -16,16 +16,22 @@ https://reactome.org/download-data?id=86&ml=1
 """
 
 REACTOME_SOURCES = {
+    'ReactomePathways':'ReactomePathways.txt',
+    'ReactomePathwayRelationships':'ReactomePathwaysRelation.txt',
     'ChEBI2Reactome': 'ChEBI2Reactome_PE_Pathway.txt',
     'UniProt2Reactome': 'UniProt2Reactome_PE_Pathway.txt'
 }
 
 REACTOME_CONFIGS = {
+    'ReactomePathways':'reactomepathways.yaml',
+    'ReactomePathwayRelationships':'reactomepathwaysrelation.yaml',
     'ChEBI2Reactome': 'chebi2reactome.yaml',
     'UniProt2Reactome': 'uniprot2reactome.yaml'
 }
 
 REACTOME_HEADERS = {
+    'ReactomePathways': 'REACT_PATH_ID\tREACT_NAME\tSPECIES\n',
+    'ReactomePathwayRelationships': 'REACT_PATH_ID\tREACT_PATH_CHILD\n',
     'ChEBI2Reactome': 'CHEBI_ID\tREACT_PE_ID\tREACT_NAME\tREACT_PATH_ID\tURL\tEVENT_NAME\tEVIDENCE\tSPECIES\n',
     'UniProt2Reactome': 'UPID\tREACT_PE_ID\tREACT_NAME\tREACT_PATH_ID\tURL\tEVENT_NAME\tEVIDENCE\tSPECIES\n'
 }
@@ -33,24 +39,25 @@ REACTOME_HEADERS = {
 TRANSLATION_TABLE = "./kg_idg/transform_utils/translation_table.yaml"
 
 class ReactomeTransform(Transform):
-    """This transform ingests the Reactome Protein (UniProt) to
+    """ This transform handles the Reactome pathway
+    list and pathway relationship (parent/child) lists.
+    Also ingests the Reactome Protein (UniProt) to
 	pathway and CHEBI to pathway files:
 	UniProt2Reactome_PE_Pathway.txt and
 	ChEBI2Reactome_PE_Pathway.txt respectively.
-	Both are transformed to KGX-format node and edge lists.
+	All are transformed to KGX-format node and edge lists.
     """
 
     def __init__(self, input_dir: str = None, output_dir: str = None) -> None:
         source_name = "reactome"
         super().__init__(source_name, input_dir, output_dir) 
 
-    def run(self, chebi_to_react_file: Optional[str] = None, 
-            uniprot_to_react_file: Optional[str] = None) -> None:  # type: ignore
+    def run(self, react_file: Optional[str] = None) -> None:  # type: ignore
         """
         Set up Reactome files for Koza and call the parse function.
         """
-        if chebi_to_react_file and uniprot_to_react_file:
-            for source in [chebi_to_react_file, uniprot_to_react_file]:
+        if react_file:
+            for source in [react_file]:
                 k = source.split('.')[0]
                 data_file = os.path.join(self.input_base_dir, source)
                 self.parse(k, data_file, k)

--- a/kg_idg/transform_utils/reactome/reactomepathways.py
+++ b/kg_idg/transform_utils/reactome/reactomepathways.py
@@ -1,0 +1,17 @@
+import uuid
+
+from biolink_model_pydantic.model import Pathway #type: ignore
+
+from koza.cli_runner import koza_app #type: ignore
+
+source_name="reactomepathways"
+full_source_name="Reactome"
+
+row = koza_app.get_row(source_name)
+
+# Entities
+pathway = Pathway(id='REACT:' + row['REACT_PATH_ID'],
+                    description= row['REACT_NAME'],
+                    source=full_source_name)
+
+koza_app.write(pathway)

--- a/kg_idg/transform_utils/reactome/reactomepathways.yaml
+++ b/kg_idg/transform_utils/reactome/reactomepathways.yaml
@@ -1,0 +1,35 @@
+name: 'reactomepathways'
+
+format: 'csv'
+
+delimiter: '\t'
+
+files:
+  - './data/raw/ReactomePathways.txt'
+
+metadata: './kg_idg/transform_utils/reactome/metadata.yaml'
+
+header: 'infer'
+
+columns:
+  - 'REACT_PATH_ID'
+  - 'REACT_NAME'
+  - 'SPECIES'
+
+node_properties:
+  - 'id'
+  - 'category'
+  - 'source'
+  - 'description'
+
+edge_properties:
+  - 'id'
+  - 'subject'
+  - 'predicate'
+  - 'object'
+  - 'category'
+  - 'relation'
+  - 'source'
+  - 'provided_by'
+
+transform_mode: 'flat'

--- a/kg_idg/transform_utils/reactome/reactomepathwaysrelation.py
+++ b/kg_idg/transform_utils/reactome/reactomepathwaysrelation.py
@@ -1,0 +1,31 @@
+import uuid
+
+from biolink_model_pydantic.model import ( #type: ignore
+    Pathway,
+    Association,
+    Predicate,
+)
+
+from koza.cli_runner import koza_app #type: ignore
+
+source_name="reactomepathwaysrelation"
+full_source_name="Reactome"
+
+row = koza_app.get_row(source_name)
+
+# Entities
+parent_pathway = Pathway(id='REACT:' + row['REACT_PATH_ID'],
+                    source=full_source_name)
+child_pathway = Pathway(id='REACT:' + row['REACT_PATH_CHILD'])
+
+# Association
+association = Association(
+    id="uuid:" + str(uuid.uuid1()),
+    subject=parent_pathway.id,
+    predicate=Predicate.contains_process,
+    object=child_pathway.id,
+    relation = "RO:0002351", #has_member,
+    source=full_source_name
+)
+
+koza_app.write(parent_pathway, association, child_pathway)

--- a/kg_idg/transform_utils/reactome/reactomepathwaysrelation.yaml
+++ b/kg_idg/transform_utils/reactome/reactomepathwaysrelation.yaml
@@ -1,0 +1,34 @@
+name: 'reactomepathwaysrelation'
+
+format: 'csv'
+
+delimiter: '\t'
+
+files:
+  - './data/raw/ReactomePathwaysRelation.txt'
+
+metadata: './kg_idg/transform_utils/reactome/metadata.yaml'
+
+header: 'infer'
+
+columns:
+  - 'REACT_PATH_ID'
+  - 'REACT_PATH_CHILD'
+
+node_properties:
+  - 'id'
+  - 'category'
+  - 'source'
+  - 'description'
+
+edge_properties:
+  - 'id'
+  - 'subject'
+  - 'predicate'
+  - 'object'
+  - 'category'
+  - 'relation'
+  - 'source'
+  - 'provided_by'
+
+transform_mode: 'flat'

--- a/kg_idg/transform_utils/reactome/uniprot2reactome.py
+++ b/kg_idg/transform_utils/reactome/uniprot2reactome.py
@@ -17,7 +17,6 @@ row = koza_app.get_row(source_name)
 # Entities
 protein = Protein(id='UniProtKB:' + row['UPID'])
 pathway = Pathway(id='REACT:' + row['REACT_PATH_ID'],
-                    description= row['EVENT_NAME'],
                     source=full_source_name)
 
 # Association

--- a/merge.yaml
+++ b/merge.yaml
@@ -77,8 +77,8 @@ merged_graph:
       input:
         format: tsv
         filename:
-          - data/transformed/gocams/GOCAMs_nodes.tsv_nodes.tsv
-          - data/transformed/gocams/GOCAMs_edges.tsv_edges.tsv
+          - data/transformed/gocams/gocams-fix-nodes_nodes.tsv
+          - data/transformed/gocams/gocams-fix-edges_edges.tsv
     hpa:
       name: "Human Proteome Atlas"
       input:

--- a/merge.yaml
+++ b/merge.yaml
@@ -135,6 +135,20 @@ merged_graph:
         filename:
           - data/transformed/orphanet/orphanet_nodes.tsv
           - data/transformed/orphanet/orphanet_edges.tsv
+    reactomepathways:
+      name: "Reactome - all pathways"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/reactome/reactomepathways_nodes.tsv
+          - data/transformed/reactome/reactomepathways_edges.tsv
+    reactomepathwaysrelation:
+      name: "Reactome - relationships between pathways"
+      input:
+        format: tsv
+        filename:
+          - data/transformed/reactome/reactomepathwaysrelation_nodes.tsv
+          - data/transformed/reactome/reactomepathwaysrelation_edges.tsv
     chebi2reactome:
       name: "Reactome - CHEBI maps"
       input:

--- a/setup.py
+++ b/setup.py
@@ -64,13 +64,14 @@ setup(
         'tqdm',
         'wget',
         'compress_json',
-        'click>=7.1.1',
+        'click',
         'pyyaml',
         'kgx==1.5.0',
         'koza==0.1.5',
         'biolink_model_pydantic==0.1.4',
         'mysql-connector-python',
-        'psycopg2-binary'
+        'psycopg2-binary',
+        'black==20.8b1'
     ],
     extras_require=extras,
 )

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'tqdm',
         'wget',
         'compress_json',
-        'click',
+        'click>=7.1.1',
         'pyyaml',
         'kgx==1.5.0',
         'koza==0.1.5',


### PR DESCRIPTION
Fix #34 

The current pre-transformed GO-CAMs are from KG-COVID-19 and are hence COVID-19 specific.
We can use a broader set.
This will require a SPARQL query as described in the linked issue.