### PR TITLE
Fix for STRING node Biolink cats

### DIFF
--- a/kg_idg/transform_utils/string/string.py
+++ b/kg_idg/transform_utils/string/string.py
@@ -46,11 +46,11 @@ class STRINGTransform(Transform):
                 self.parse(name, data_file, k)
     
     def filter(self, name: str, data_file: str) -> None:
-        
-        # Do quality screen here - combined score must be >=
-        # CONFIDENCE_THRESHOLD value
-
-        # TODO: make this faster with mmap or the like
+        """
+        Do quality screen here - combined score must be >=
+        CONFIDENCE_THRESHOLD value.
+        Also adds NamedThing to Biolink categories in nodefile.
+        """
 
         new_edge_file_path = os.path.join(os.path.dirname(data_file),
                             'string_edges_filtered.tsv')
@@ -68,12 +68,35 @@ class STRINGTransform(Transform):
         os.rename(data_file, os.path.join(os.path.dirname(data_file),'string_edges_full.tsv'))
         os.rename(new_edge_file_path, os.path.join(os.path.dirname(data_file),STRING_SOURCES['STRINGEdges']))
 
+    def add_biolink_cat(self, name: str, data_file: str) -> None:
+        """
+        Adds the NamedThing Biolink category to nodes.
+        """
+
+        new_node_file_path = os.path.join(os.path.dirname(data_file),
+                            'string_nodes_updated.tsv')
+
+        with open(new_node_file_path, 'w') as new_node_file, \
+                open(data_file, 'r') as raw_node_file:
+            new_node_file.write(raw_node_file.readline()) # Header
+            for line in raw_node_file:
+                splitline = (line.rstrip()).split("\t")
+                splitline[2] = splitline[2] + "|biolink:NamedThing"
+                new_node_file.write("\t".join(splitline) + "\n")
+
+        os.rename(data_file, os.path.join(os.path.dirname(data_file),'string_nodes_full.tsv'))
+        os.rename(new_node_file_path, os.path.join(os.path.dirname(data_file),STRING_SOURCES['STRINGNodes']))
+
     def parse(self, name: str, data_file: str, source: str) -> None:
         print(f"Parsing {data_file}")
 
         if name == STRING_SOURCES['STRINGEdges']:
             print(f"Parsing edges in {name}")
             self.filter(name, data_file)
+        
+        if name == STRING_SOURCES['STRINGNodes']:
+            print(f"Updating Biolink categories in {name}")
+            self.add_biolink_cat(name, data_file)
 
         transform(inputs=[data_file],
                   input_format='tsv',


### PR DESCRIPTION
STRING nodes didn't have NamedThing Biolink category.
Now they do.