### PR TITLE
Resolving earlier dependency conflicts

### DIFF
--- a/download.yaml
+++ b/download.yaml
@@ -78,7 +78,6 @@
 -
   # Pharos/TCRD - just the ID mappings
   # url: http://juniper.health.unm.edu/tcrd/download/TCRDv6.12.4.tsv
-  
   # Using cached version here
   url: https://kg-hub.berkeleybop.io/kg-idg/20220216/raw/TCRDv6.12.4.tsv
   local_name: TCRDv6.12.4.tsv
@@ -86,7 +85,6 @@
   # TCRD database dump - note this is > 40G
   # TODO: if possible, source TCRD ID maps directly from this source, avoiding redundancy
   # url: http://juniper.health.unm.edu/tcrd/download/old_versions/TCRDv6.12.4.sql.gz
-  
   # Using cached version here
   url: https://kg-hub.berkeleybop.io/kg-idg/20220216/raw/tcrd.sql.gz
   local_name: tcrd.sql.gz

--- a/download.yaml
+++ b/download.yaml
@@ -77,12 +77,18 @@
   local_name: go_kgx_tsv.tar.gz
 -
   # Pharos/TCRD - just the ID mappings
-  url: http://juniper.health.unm.edu/tcrd/download/TCRDv6.12.4.tsv
+  # url: http://juniper.health.unm.edu/tcrd/download/TCRDv6.12.4.tsv
+  
+  # Using cached version here
+  url: https://kg-hub.berkeleybop.io/kg-idg/20220216/raw/TCRDv6.12.4.tsv
   local_name: TCRDv6.12.4.tsv
 -
   # TCRD database dump - note this is > 40G
   # TODO: if possible, source TCRD ID maps directly from this source, avoiding redundancy
-  url: http://juniper.health.unm.edu/tcrd/download/old_versions/TCRDv6.12.4.sql.gz
+  # url: http://juniper.health.unm.edu/tcrd/download/old_versions/TCRDv6.12.4.sql.gz
+  
+  # Using cached version here
+  url: https://kg-hub.berkeleybop.io/kg-idg/20220216/raw/tcrd.sql.gz
   local_name: tcrd.sql.gz
 -
   # OGMS

--- a/kg_idg/transform_utils/atc/atc-classes.yaml
+++ b/kg_idg/transform_utils/atc/atc-classes.yaml
@@ -1,7 +1,5 @@
 name: 'atc-classes'
 
-format: 'csv'
-
 delimiter: ','
 
 files:

--- a/kg_idg/transform_utils/drug_central/drugcentral-dti.yaml
+++ b/kg_idg/transform_utils/drug_central/drugcentral-dti.yaml
@@ -1,7 +1,5 @@
 name: 'drugcentral-dti'
 
-format: 'csv'
-
 delimiter: '\t'
 
 files:

--- a/kg_idg/transform_utils/gocams/gocams-fix-edges.yaml
+++ b/kg_idg/transform_utils/gocams/gocams-fix-edges.yaml
@@ -1,7 +1,5 @@
 name: 'gocams-fix-edges'
 
-format: 'csv'
-
 delimiter: '\t'
 
 files:

--- a/kg_idg/transform_utils/gocams/gocams-fix-nodes.yaml
+++ b/kg_idg/transform_utils/gocams/gocams-fix-nodes.yaml
@@ -1,7 +1,5 @@
 name: 'gocams-fix-nodes'
 
-format: 'csv'
-
 delimiter: '\t'
 
 files:

--- a/kg_idg/transform_utils/hpa/hpa-data.yaml
+++ b/kg_idg/transform_utils/hpa/hpa-data.yaml
@@ -1,7 +1,5 @@
 name: 'hpa-data'
 
-format: 'csv'
-
 delimiter: '\t'
 
 files:

--- a/kg_idg/transform_utils/reactome/reactomepathways.yaml
+++ b/kg_idg/transform_utils/reactome/reactomepathways.yaml
@@ -1,7 +1,5 @@
 name: 'reactomepathways'
 
-format: 'csv'
-
 delimiter: '\t'
 
 files:

--- a/kg_idg/transform_utils/reactome/reactomepathwaysrelation.yaml
+++ b/kg_idg/transform_utils/reactome/reactomepathwaysrelation.yaml
@@ -1,7 +1,5 @@
 name: 'reactomepathwaysrelation'
 
-format: 'csv'
-
 delimiter: '\t'
 
 files:

--- a/kg_idg/transform_utils/tcrd/tcrd-ids.yaml
+++ b/kg_idg/transform_utils/tcrd/tcrd-ids.yaml
@@ -1,7 +1,5 @@
 name: 'tcrd-ids'
 
-format: 'csv'
-
 delimiter: '\t'
 
 files:

--- a/kg_idg/transform_utils/tcrd/tcrd-protein.yaml
+++ b/kg_idg/transform_utils/tcrd/tcrd-protein.yaml
@@ -1,7 +1,5 @@
 name: 'tcrd-protein'
 
-format: 'csv'
-
 delimiter: '\t'
 
 files:

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'click',
         'pyyaml',
         'kgx==1.5.5',
-        'koza==0.1.5',
+        'koza@git+https://github.com/monarch-initiative/koza.git#61289d3cab8eec9a6609334d112492bce27d8eeb',
         'biolink_model_pydantic==0.1.4',
         'mysql-connector-python',
         'psycopg2-binary',

--- a/setup.py
+++ b/setup.py
@@ -66,12 +66,11 @@ setup(
         'compress_json',
         'click',
         'pyyaml',
-        'kgx==1.5.0',
+        'kgx==1.5.5',
         'koza==0.1.5',
         'biolink_model_pydantic==0.1.4',
         'mysql-connector-python',
         'psycopg2-binary',
-        'black==20.8b1'
     ],
     extras_require=extras,
 )


### PR DESCRIPTION
Upstream `linkml` created a dependency conflict re: `click` - solution is to upgrade `kgx`.
Also fixing some issues with obsolete Koza config format (the *format* field is no longer necessary) - this also requires bumping `koza` to 0.1.7