### PR TITLE
let kgx freely update to get infores/knowledge source fixes in 1.7.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         'compress_json',
         'grape',
         'kghub-downloader',
-        'kgx==1.5.9',
+        'kgx',
         'koza>=0.2.1',
         'linkml-validator @ git+https://github.com/linkml/linkml-validator.git',
         'multi-indexer',


### PR DESCRIPTION
my tests in both KGX and locally with this repo, show aggregator_knowledge_source being added to edge files even when knowledge_source is provided in the files to transform.  Keeping the changelog small, I think if we let KGX freely float, it will pick up the updates to the infores/knowledge source fixes in KGX. 