### PR TITLE
Install `ensmallen` dependencies during Jenkins run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,9 @@ pipeline {
                     // Now move on to the actual install + reqs
                     sh './venv/bin/pip install .'
                     sh './venv/bin/pip install awscli boto3 s3cmd'
+
+                    // Temporary - install dependencies for ensmallen
+                    sh './venv/bin/pip install toml~=0.10.0 downloaders>=1.0.15 compress_json>=1.0.7 userinput>=1.0.19 cache_decorator>=2.1.11 bioregistry>=0.5.65 tqdm pandas py-cpuinfo environments_utils>=1.0.4'
                 }
             }
         }


### PR DESCRIPTION
See https://github.com/AnacletoLAB/ensmallen/issues/192 - subgraph generation fails due to missing `ensmallen` dependencies.
So for now, they're getting installed during the build.